### PR TITLE
Added minimum width breakpoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,21 @@ in this case because &lt;div class="column"&gt; elements are top level children 
 
 #### Options
 
+#####equialize_interval
 By default, the equalizing function is called only on window resize.
 You can change this default behavior by setting the `equalize_interval` option.
 If `equalize_interval` is specified with a number value, for example, `500`, then the equalizing function is called every 500ms:
+#####breakPoint
+minimum width `breakPoint` option under which the plug-in will be ignored.
+
+This is useful for responsive designs, in which floating element should be the same height side by side, but for smaller screens the elements are stacked and should have auto height.
 
 ```javascript
 /* call the equalizing function every 500ms*/
-$(".row").eqHeight(".column", {equalize_interval: 500});
+$(".row").eqHeight(".column", {
+    equalize_interval: 500, 
+    breakPoint:568
+});
 ```
 
 ### Use with existing responsive grid systems

--- a/jquery.eqheight.js
+++ b/jquery.eqheight.js
@@ -18,7 +18,8 @@ Licensed under GPL v2.
     eqHeight: function(column_selector, option) {
       if (option == null) {
         option = {
-          equalize_interval: null
+          equalize_interval: null,
+		  breakPoint: null
         };
       }
       return this.each(function() {
@@ -58,7 +59,15 @@ Licensed under GPL v2.
         };
         start_equalizing = function() {
           clearTimeout(timer);
-          return timer = setTimeout(equalizer, 100);
+		  if (typeof option.breakPoint === "number"){
+			if($(window).width()> option.breakPoint){
+				return timer = setTimeout(equalizer, 100);
+			}else{
+				columns.height("auto");	
+			}
+		  }else{
+	          return timer = setTimeout(equalizer, 100);
+		  }
         };
         infinite_equalizing = function() {
           equalizer();


### PR DESCRIPTION
Added minimum width breakpoint option under which the plug-in will be ignored
This is useful for responsive designs, in which floating element should be the same height side by side, by for smaller screens the elements are stacked and should  have auto height.
